### PR TITLE
Fixed raw orderby in highest res image scope

### DIFF
--- a/src/TippingCanoe/Imager/Model/Image.php
+++ b/src/TippingCanoe/Imager/Model/Image.php
@@ -95,7 +95,7 @@ class Image extends Model {
 	 * @return Builder
 	 */
 	public function scopeHighestRes(Builder $query) {
-		return $query->orderByRaw('width * height', 'DESC');
+		return $query->orderByRaw('(width * height) DESC');
 	}
 
 	/**


### PR DESCRIPTION
Small change to image model scope to use the raw orderby correctly.
