### PR TITLE
Made sure to handle the case where Imageable is not provided

### DIFF
--- a/src/TippingCanoe/Imager/Service.php
+++ b/src/TippingCanoe/Imager/Service.php
@@ -121,7 +121,7 @@ class Service {
 	 * @return string
 	 */
 	public function getPublicUriBySlot($slot, Imageable $imageable = null, $filters = []) {
-		return $this->getPublicUri($imageable->images()->inSlot($slot), $filters);
+		return $this->getPublicUri($this->getBySlot($slot, $imageable), $filters);
 	}
 
 	/**


### PR DESCRIPTION
getPublicUriBySlot needed a way to retrieve loose images that were not attached to a model.
